### PR TITLE
Fix decrement of iterator rvalue issue

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -9,8 +9,12 @@ mstch::citer mstch::first_not_ws(mstch::citer begin, mstch::citer end) {
 
 mstch::citer mstch::first_not_ws(mstch::criter begin, mstch::criter end) {
   for (auto rit = begin; rit != end; ++rit)
-    if (*rit != ' ') return --(rit.base());
-  return --(end.base());
+    if (*rit != ' ') {
+      auto tmp = rit.base();
+      return --tmp;
+    }
+  auto tmp = end.base();
+  return --tmp;
 }
 
 mstch::criter mstch::reverse(mstch::citer it) {


### PR DESCRIPTION
Fix issue #9 by storing iterator in a temporary variable before using decrement operator.

Compiles successfully on platforms with both types of iterators, and continues to pass all unit tests.
