### PR TITLE
Do not hardcode Release as the build type and expose Boost_INCLUDE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ option(WITH_BENCHMARK "enable building benchmark executable" OFF)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_INCLUDE_CURRENT_DIR_IN_INTERFACE ON)
-set(CMAKE_BUILD_TYPE Release)
 
 set(mstch_VERSION 1.0.1)
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,11 @@ from the root of the source tree:
  $ make install
 ```
 
-The install command may require root privileges. This will also install CMake 
+You can specify the
+[build type](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html) (Release, Debug...)
+by adding -DCMAKE\_BUILD\_TYPE=BuildType to the `cmake` command.
+
+The install command may require root privileges. This will also install CMake
 config files, so you can use use `find_package` in your CMakeLists.txt:
 
 ```cmake

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,8 @@ add_library(mstch STATIC ${SRC})
 
 set_property(TARGET mstch PROPERTY VERSION ${mstch_VERSION})
 
+target_include_directories(mstch PUBLIC ${Boost_INCLUDE_DIR})
+
 install(
     TARGETS mstch EXPORT mstchTargets
     LIBRARY DESTINATION lib


### PR DESCRIPTION
This branch gives developers a little bit of flexibility for the build type.

* Allow the developer to set by himself CMAKE_BUILD_TYPE instead of a hardcoded Release
* Expose Boost_INCLUDE_DIR as a public include directory of the target `mstch` since some public headers include Boost's headers.
