### PR TITLE
Add a render overload that takes a functor for partials.

### DIFF
--- a/include/mstch/mstch.hpp
+++ b/include/mstch/mstch.hpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <functional>
 
+#include <boost/optional.hpp>
 #include <boost/variant.hpp>
 
 namespace mstch {
@@ -110,4 +111,8 @@ std::string render(
     const std::map<std::string,std::string>& partials =
         std::map<std::string,std::string>());
 
+std::string render(
+    const std::string& tmplt,
+    const node& root,
+	std::function<boost::optional<std::string>(const std::string&)> partial_loader);
 }

--- a/include/mstch/mstch.hpp
+++ b/include/mstch/mstch.hpp
@@ -8,6 +8,7 @@
 
 #include <boost/optional.hpp>
 #include <boost/variant.hpp>
+#include <boost/utility/string_view.hpp>
 
 namespace mstch {
 
@@ -99,7 +100,7 @@ using node = boost::make_recursive_variant<
     internal::lambda_t<boost::recursive_variant_>,
     std::shared_ptr<internal::object_t<boost::recursive_variant_>>,
     std::map<const std::string, boost::recursive_variant_>,
-    std::vector<boost::recursive_variant_>>::type;
+    std::vector<boost::recursive_variant_>, boost::string_view>::type;
 using object = internal::object_t<node>;
 using lambda = internal::lambda_t<node>;
 using map = std::map<const std::string, node>;

--- a/src/mstch.cpp
+++ b/src/mstch.cpp
@@ -12,9 +12,19 @@ std::string mstch::render(
     const node& root,
     const std::map<std::string,std::string>& partials)
 {
-  std::map<std::string, template_type> partial_templates;
-  for (auto& partial: partials)
-    partial_templates.insert({partial.first, {partial.second}});
+  return render(tmplt, root, [&partials](const std::string& partial_name) {
+    return partials.count(partial_name) ?
+        boost::make_optional(partials.at(partial_name))
+	  :
+        boost::optional<std::string>()
+      ;
+  });
+}
 
-  return render_context(root, partial_templates).render(tmplt);
+std::string mstch::render(
+    const std::string& tmplt,
+    const node& root,
+	std::function<boost::optional<std::string>(const std::string&)> partial_loader)
+{
+  return render_context(root, partial_loader).render(tmplt);
 }

--- a/src/render_context.cpp
+++ b/src/render_context.cpp
@@ -26,8 +26,8 @@ std::string render_context::push::render(const template_type& templt) {
 
 render_context::render_context(
     const mstch::node& node,
-    const std::map<std::string, template_type>& partials):
-    m_partials(partials), m_nodes(1, node), m_node_ptrs(1, &node)
+    const std::function<boost::optional<std::string>(const std::string&)> partials):
+    m_partial_resolv(partials), m_nodes(1, node), m_node_ptrs(1, &node)
 {
   m_state.push(std::unique_ptr<render_state>(new outside_section));
 }
@@ -67,6 +67,9 @@ std::string render_context::render(
 std::string render_context::render_partial(
     const std::string& partial_name, const std::string& prefix)
 {
-  return m_partials.count(partial_name) ?
-      render(m_partials.at(partial_name), prefix) : "";
+  auto value = m_partial_resolv(partial_name);
+  if (value)
+    return render(template_type{*value}, prefix);
+  else
+    return "";
 }

--- a/src/render_context.hpp
+++ b/src/render_context.hpp
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <string>
 #include <stack>
+#include <functional>
 
 #include "mstch/mstch.hpp"
 #include "state/render_state.hpp"
@@ -25,7 +26,7 @@ class render_context {
 
   render_context(
       const mstch::node& node,
-      const std::map<std::string, template_type>& partials);
+      const std::function<boost::optional<std::string>(const std::string&)> partials);
   const mstch::node& get_node(const std::string& token);
   std::string render(
       const template_type& templt, const std::string& prefix = "");
@@ -42,7 +43,7 @@ class render_context {
   const mstch::node& find_node(
       const std::string& token,
       std::list<node const*> current_nodes);
-  std::map<std::string, template_type> m_partials;
+  std::function<boost::optional<std::string>(const std::string&)> m_partial_resolv;
   std::deque<mstch::node> m_nodes;
   std::list<const mstch::node*> m_node_ptrs;
   std::stack<std::unique_ptr<render_state>> m_state;

--- a/src/visitor/is_node_empty.hpp
+++ b/src/visitor/is_node_empty.hpp
@@ -30,7 +30,11 @@ class is_node_empty: public boost::static_visitor<bool> {
   }
 
   bool operator()(const std::string& value) const {
-    return value == "";
+    return value.empty();
+  }
+
+  bool operator()(const boost::string_view& value) const {
+    return value.empty();
   }
 
   bool operator()(const array& array) const {

--- a/src/visitor/render_node.hpp
+++ b/src/visitor/render_node.hpp
@@ -36,6 +36,10 @@ class render_node: public boost::static_visitor<std::string> {
     return value ? "true" : "false";
   }
 
+  std::string operator()(const boost::string_view& value) const {
+    return std::string(value);
+  }
+
   std::string operator()(const lambda& value) const {
     template_type interpreted{value([this](const mstch::node& n) {
       return visit(render_node(m_ctx), n);


### PR DESCRIPTION
This addresses issue #13 with minimal effort from the user. Users need to provide a functor that takes a string and returns the content of the partial being requested as an optional string. The old behaviour is maintained by default, though it's now implemented in terms of the new render() overload.

One consideration is that now template_type is constructed only when a partial is requested, as opposed to being pre-constructed pre-emptively inside render(). If a template uses the same partial several times (unlikely, imo) template_type is constructed every time. I have no idea of how expensive that is, so this might be a non-issue. Please do let me know if there's anything to make this code look better.