### PR TITLE
generate position independent code

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SRC
     utils.cpp)
 
 add_library(mstch STATIC ${SRC})
+set_property(TARGET mstch PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 set_property(TARGET mstch PROPERTY VERSION ${mstch_VERSION})
 


### PR DESCRIPTION
Using mstch in a shared object currently fails:

    /usr/bin/ld: lib/mstch/src/libmstch.a(mstch.cpp.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
    /usr/bin/ld: lib/mstch/src/libmstch.a(render_context.cpp.o): relocation R_X86_64_32S against symbol `_ZTVN5mstch15outside_sectionE' can not be used when making a shared object; recompile with -fPIC
    /usr/bin/ld: lib/mstch/src/libmstch.a(template_type.cpp.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
    /usr/bin/ld: lib/mstch/src/libmstch.a(token.cpp.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
    /usr/bin/ld: lib/mstch/src/libmstch.a(utils.cpp.o): relocation R_X86_64_32 against symbol `_ZN5mstch6config6escapeB5cxx11E' can not be used when making a shared object; recompile with -fPIC
    /usr/bin/ld: lib/mstch/src/libmstch.a(outside_section.cpp.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
    /usr/bin/ld: lib/mstch/src/libmstch.a(in_section.cpp.o): relocation R_X86_64_32S against symbol `_ZTVN5mstch10in_sectionE' can not be used when making a shared object; recompile with -fPIC

This PR addresses the issue by applying the linker's suggestion: Generating Posiion Independent Code