### PR TITLE
Move include declarations to targets for export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,9 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(mstch)
 
 option(WITH_UNIT_TESTS "enable building unit test executable" OFF)
 option(WITH_BENCHMARK "enable building benchmark executable" OFF)
 
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_INCLUDE_CURRENT_DIR_IN_INTERFACE ON)
 set(CMAKE_BUILD_TYPE Release)
 
 set(mstch_VERSION 1.0.1)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,9 @@
 find_package(Boost 1.54 REQUIRED)
 
-set(mstch_INCLUDE_DIR
-    ${PROJECT_SOURCE_DIR}/include CACHE STRING "mstch include directory")
-
-include_directories(
-    ${mstch_INCLUDE_DIR}
-    ${Boost_INCLUDE_DIR})
+# Define headers for this library. PUBLIC headers are used for compiling
+# the library, and will be added to consumers' build paths.
+set(BUILD_INCLUDE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
+set(INSTALL_INCLUDE $<INSTALL_INTERFACE:include>)
 
 set(SRC
     state/in_section.cpp
@@ -25,6 +23,11 @@ set(SRC
 add_library(mstch STATIC ${SRC})
 
 set_property(TARGET mstch PROPERTY VERSION ${mstch_VERSION})
+target_include_directories(mstch PUBLIC
+    ${BUILD_INCLUDE}
+    ${INSTALL_INCLUDE}
+    PRIVATE .)
+target_link_libraries(mstch Boost::boost)
 
 install(
     TARGETS mstch EXPORT mstchTargets


### PR DESCRIPTION
Declaring include directories on targets has the benefit that the
declarations are propagated to the `INTERFACE_INCLUDE_DIRECTORIES`
property in the CMake package file. This ensures that downstream
projects can link to the imported CMake targets and get the correct
include directories set automatically.

The `target_include_directories` declarations follow the recommendation
https://cmake.org/cmake/help/latest/command/target_include_directories.html
so that the packages are **relocatable**. This in turn allows
installing and testing without requiring `root` permissions.

Following same recommendations, Boost headers are included using the
imported target `Boost::boost`. This is available starting from CMake
version 3.5, and the required version is updated accordingly.

Signed-off-by: Eero Aaltonen <eero.aaltonen@vaisala.com>